### PR TITLE
Option to remove chunk manifest asset

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ module.exports = {
         template: './index-template.ejs'
     }),
     // InlineChunkManifestHtmlWebpackPlugin defaults to:
-    // { filename: 'manifest.json', manifestVariable: 'webpackManifest', chunkManifestVariable: 'webpackChunkManifest' }
+    // { filename: 'manifest.json', manifestVariable: 'webpackManifest', chunkManifestVariable: 'webpackChunkManifest', dropAsset: false }
     // match { filename, manifestVariable } with ChunkManifestPlugin
     new InlineChunkManifestHtmlWebpackPlugin(),
     new InlineManifestPlugin()
@@ -43,6 +43,7 @@ const inlineChunkManifestConfig = {
   filename: 'manifest.json', // manifest.json is default; matches chunk-manifest-webpack-plugin
   manifestVariable: 'webpackManifest', // webpackManifest is default; matches chunk-manifest-webpack-plugin
   chunkManifestVariable: 'webpackChunkManifest' // webpackChunkManifest is default; use in html-webpack-plugin template
+  dropAsset: true // false is default; use to skip output of the chunk manifest asset (removes manifest.json)
 };
 
 new InlineChunkManifestHtmlWebpackPlugin(inlineChunkManifestConfig)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inline-chunk-manifest-html-webpack-plugin",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Plugin to inline webpack chunk manifest. Default inlines in head tag. Use together with html-webpack-plugin, chunk-manifest-webpack-plugin and inline-manifest-webpack-plugin.",
   "main": "./src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -3,12 +3,14 @@ function InlineChunkManifestHtmlWebpackPlugin(options) {
     this.manifestFilename = options.filename || "manifest.json";
     this.manifestVariable = options.manifestVariable || "webpackManifest";
     this.chunkManifestVariable = options.chunkManifestVariable || "webpackChunkManifest";
+    this.dropAsset = options.dropAsset || false;
 }
 
 InlineChunkManifestHtmlWebpackPlugin.prototype.apply = function (compiler) {
     const manifestFilename = this.manifestFilename;
     const manifestVariable = this.manifestVariable;
     const chunkManifestVariable = this.chunkManifestVariable;
+    const dropAsset = this.dropAsset;
 
     compiler.plugin("compilation", function (compilation) {
         compilation.plugin('html-webpack-plugin-alter-asset-tags', function (htmlPluginData, callback) {
@@ -25,6 +27,10 @@ InlineChunkManifestHtmlWebpackPlugin.prototype.apply = function (compiler) {
                 };
 
                 htmlPluginData.head.unshift(newTag);
+
+                if(dropAsset) {
+                    delete compilation.assets[manifestFilename];
+                }
             }
 
             callback(null, htmlPluginData);


### PR DESCRIPTION
Added option to not output the chunk manifest asset, as requested in https://github.com/jouni-kantola/inline-chunk-manifest-html-webpack-plugin/issues/5.

Now the chunk manifest asset can be kept if one wants to, but still easy to clean if needed.