### PR TITLE
Override default manifest plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ const inlineChunkManifestConfig = {
   filename: 'manifest.json', // manifest.json is default
   manifestVariable: 'webpackManifest', // webpackManifest is default
   chunkManifestVariable: 'webpackChunkManifest', // webpackChunkManifest is default; use in html-webpack-plugin template
-  dropAsset: true // false is default; use to skip output of the chunk manifest asset (removes manifest.json)
+  dropAsset: true, // false is default; use to skip output of the chunk manifest asset (removes manifest.json)
+  manifestPlugins: [/* override default chunk manifest plugin(s) */]
 };
 
 new InlineChunkManifestHtmlWebpackPlugin(inlineChunkManifestConfig)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,53 @@ Example template for `html-webpack-plugin`:
   <body>
     <h1>My web site</h1>
     <%=htmlWebpackPlugin.files.webpackChunkManifest%>
-    <%=htmlWebpackPlugin.files.webpackManifest%>
   </body>
 </html>
+```
+
+### Override default chunk manifest plugin
+To use plugins like [webpack-manifest-plugin](https://github.com/danethurber/webpack-manifest-plugin) you can override the default plugin used to extract the webpack chunk manifest. To do this, you can do either of below configs:
+
+`inline-chunk-manifest-html-webpack-plugin` apply dependency plugins:
+```javascript
+const InlineChunkManifestHtmlWebpackPlugin = require('inline-chunk-manifest-html-webpack-plugin');
+
+module.exports = {
+  /* webpack config */
+  plugins: [
+    /* more plugins goes here */
+
+    new InlineChunkManifestHtmlWebpackPlugin({
+      manifestPlugins: [
+        new WebpackManifestPlugin()
+      ],
+      manifestVariable: "manifest"
+    }),
+    new HtmlWebpackPlugin({
+        template: './index-template.ejs'
+    })
+    /* more plugins goes here */
+  ]
+};
+```
+
+Plugins applied separately:
+```javascript
+const InlineChunkManifestHtmlWebpackPlugin = require('inline-chunk-manifest-html-webpack-plugin');
+
+module.exports = {
+  /* webpack config */
+  plugins: [
+    /* more plugins goes here */
+    new WebpackManifestPlugin(),
+    new InlineChunkManifestHtmlWebpackPlugin({
+      manifestVariable: "manifest",
+      extractManifest: false
+    }),
+    new HtmlWebpackPlugin({
+        template: './index-template.ejs'
+    })
+    /* more plugins goes here */
+  ]
+};
 ```

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ const inlineChunkManifestConfig = {
   manifestVariable: 'webpackManifest', // webpackManifest is default
   chunkManifestVariable: 'webpackChunkManifest', // webpackChunkManifest is default; use in html-webpack-plugin template
   dropAsset: true, // false is default; use to skip output of the chunk manifest asset (removes manifest.json)
-  manifestPlugins: [/* override default chunk manifest plugin(s) */]
+  manifestPlugins: [/* override default chunk manifest plugin(s) */],
+  extractManifest: false // true is default. When set to false, manifestPlugins (incl default) is not applied
 };
 
 new InlineChunkManifestHtmlWebpackPlugin(inlineChunkManifestConfig)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inline-chunk-manifest-html-webpack-plugin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Extension plugin for html-webpack-plugin to inline webpack chunk manifest. Default inlines in head tag.",
   "main": "./src/index.js",
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -12,12 +12,24 @@ class InlineChunkManifestHtmlWebpackPlugin {
       options.chunkManifestVariable || "webpackChunkManifest";
     this.dropAsset = options.dropAsset || false;
 
-    this.plugins = [
+    const manifestPlugins = options.manifestPlugins;
+
+    if (manifestPlugins && !Array.isArray(manifestPlugins)) {
+      throw new TypeError(
+        "Overriden manifest plugin(s) must be specified as array; [new Plugin1(), new Plugin1(), ...]"
+      );
+    }
+
+    const defaultManifestPlugins = [
       new ChunkManifestPlugin({
         filename: this.manifestFilename,
         manifestVariable: this.manifestVariable
       })
     ];
+
+    this.plugins = manifestPlugins && manifestPlugins.length
+      ? manifestPlugins
+      : defaultManifestPlugins;
   }
 
   apply(compiler) {

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,17 @@ class InlineChunkManifestHtmlWebpackPlugin {
       options.chunkManifestVariable || "webpackChunkManifest";
     this.dropAsset = options.dropAsset || false;
 
+    if (
+      options.extractManifest != null &&
+      typeof options.extractManifest !== "boolean"
+    ) {
+      throw new TypeError("Extract manifest must be boolean");
+    }
+
+    this.extractManifest = options.extractManifest != null
+      ? options.extractManifest
+      : true;
+
     const manifestPlugins = options.manifestPlugins;
 
     if (manifestPlugins && !Array.isArray(manifestPlugins)) {
@@ -89,7 +100,9 @@ class InlineChunkManifestHtmlWebpackPlugin {
   }
 
   applyDependencyPlugins(compiler) {
-    this.plugins.forEach(plugin => plugin.apply.call(plugin, compiler));
+    if (this.extractManifest) {
+      this.plugins.forEach(plugin => plugin.apply.call(plugin, compiler));
+    }
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,14 @@ class InlineChunkManifestHtmlWebpackPlugin {
     const chunkManifestVariable = this.chunkManifestVariable;
     const dropAsset = this.dropAsset;
 
+    compiler.plugin("emit", (compilation, callback) => {
+      if (dropAsset) {
+        delete compilation.assets[manifestFilename];
+      }
+
+      callback();
+    });
+
     compiler.plugin("compilation", compilation => {
       compilation.plugin(
         "html-webpack-plugin-alter-asset-tags",
@@ -57,10 +65,6 @@ class InlineChunkManifestHtmlWebpackPlugin {
             };
 
             htmlPluginData.head.unshift(newTag);
-
-            if (dropAsset) {
-              delete compilation.assets[manifestFilename];
-            }
           }
 
           callback(null, htmlPluginData);

--- a/test/plugin-apply-test.js
+++ b/test/plugin-apply-test.js
@@ -31,3 +31,28 @@ test.cb("dependency plugins are applied", t => {
   plugin.plugins = [dependencyPlugin, anotherDependencyPlugin];
   plugin.apply(fakeCompiler);
 });
+
+test.cb("overridden manifest plugins applied", t => {
+  t.plan(2);
+
+  const fakeCompiler = { plugin: () => {} };
+
+  const dependencyPlugin = {
+    apply: compiler => {
+      t.is(compiler, fakeCompiler);
+    }
+  };
+
+  const anotherDependencyPlugin = {
+    apply: compiler => {
+      t.is(compiler, fakeCompiler);
+      t.end();
+    }
+  };
+
+  const plugin = new InlineChunkManifestHtmlWebpackPlugin({
+    manifestPlugins: [dependencyPlugin, anotherDependencyPlugin]
+  });
+
+  plugin.apply(fakeCompiler);
+});

--- a/test/plugin-create-asset-test.js
+++ b/test/plugin-create-asset-test.js
@@ -26,20 +26,20 @@ test.cb("create asset", t => {
     }
   };
 
-  const pluginEvent = (compilerEvent, compile) => {
-    t.is(compilerEvent, "compilation");
+  const pluginEvent = (event, compile) => {
+    if (event === "compilation") {
+      const assets = {};
+      assets[manifestFilename] = {
+        source: () => manifestFileContent
+      };
 
-    const assets = {};
-    assets[manifestFilename] = {
-      source: () => manifestFileContent
-    };
+      const compilation = {
+        plugin: compilationPluginEvent,
+        assets: assets
+      };
 
-    const compilation = {
-      plugin: compilationPluginEvent,
-      assets: assets
-    };
-
-    compile(compilation);
+      compile(compilation);
+    }
   };
 
   const fakeCompiler = { plugin: pluginEvent };

--- a/test/plugin-drop-asset-test.js
+++ b/test/plugin-drop-asset-test.js
@@ -20,31 +20,20 @@ test.cb("keep asset", t => {
 });
 
 function isDropped(dropAsset, callback) {
-  const assets = {};
-  assets[manifestFilename] = {
+  const compilation = {
+    assets: {}
+  };
+  compilation.assets[manifestFilename] = {
     source: () => manifestFileContent
   };
 
-  const compilationPluginEvent = (compilationEvent, alterAssets) => {
-    if (compilationEvent === "html-webpack-plugin-alter-asset-tags") {
-      const htmlPluginData = {
-        head: []
-      };
-
-      alterAssets(htmlPluginData, (_, result) => {
-        const asset = assets[manifestFilename];
+  const pluginEvent = (event, emit) => {
+    if (event === "emit") {
+      emit(compilation, () => {
+        const asset = compilation.assets[manifestFilename];
         callback(asset);
       });
     }
-  };
-
-  const pluginEvent = (compilerEvent, compile) => {
-    const compilation = {
-      plugin: compilationPluginEvent,
-      assets: assets
-    };
-
-    compile(compilation);
   };
 
   const fakeCompiler = { plugin: pluginEvent };

--- a/test/plugin-init-test.js
+++ b/test/plugin-init-test.js
@@ -53,3 +53,36 @@ test("override chunk manifest variable", t => {
 
   t.is(plugin.chunkManifestVariable, "another-variable");
 });
+
+test("fallback to default chunk manifest plugin", t => {
+  const plugin = new InlineChunkManifestHtmlWebpackPlugin({
+    manifestPlugins: []
+  });
+
+  t.is(plugin.plugins.length, 1);
+  t.true(plugin.plugins[0] instanceof ChunkManifestPlugin);
+});
+
+test("ensure overriden plugins handle apply", t => {
+  const manifestPlugin = { override: true, apply: () => {} };
+  const anotherManifestPlugin = { override: true, apply: () => {} };
+
+  const plugin = new InlineChunkManifestHtmlWebpackPlugin({
+    manifestPlugins: [manifestPlugin, anotherManifestPlugin]
+  });
+
+  t.deepEqual(plugin.plugins, [manifestPlugin, anotherManifestPlugin]);
+});
+
+test("array of plugins required", t => {
+  const error = t.throws(() => {
+    const plugin = new InlineChunkManifestHtmlWebpackPlugin({
+      manifestPlugins: 1
+    });
+  }, TypeError);
+
+  t.is(
+    error.message,
+    "Overriden manifest plugin(s) must be specified as array; [new Plugin1(), new Plugin1(), ...]"
+  );
+});

--- a/test/plugin-init-test.js
+++ b/test/plugin-init-test.js
@@ -26,6 +26,30 @@ test("override drop asset", t => {
   t.is(plugin.dropAsset, true);
 });
 
+test("extract manifest as boolean", t => {
+  const error = t.throws(() => {
+    const plugin = new InlineChunkManifestHtmlWebpackPlugin({
+      extractManifest: 1
+    });
+  }, TypeError);
+
+  t.is(error.message, "Extract manifest must be boolean");
+});
+
+test("default extract manifest", t => {
+  const plugin = new InlineChunkManifestHtmlWebpackPlugin();
+
+  t.is(plugin.extractManifest, true);
+});
+
+test("disable plugins", t => {
+  const plugin = new InlineChunkManifestHtmlWebpackPlugin({
+    extractManifest: false
+  });
+
+  t.is(plugin.extractManifest, false);
+});
+
 test("override manifest filename", t => {
   const plugin = new InlineChunkManifestHtmlWebpackPlugin({
     filename: "another.file"

--- a/test/plugin-inject-manifest-test.js
+++ b/test/plugin-inject-manifest-test.js
@@ -27,20 +27,20 @@ test.cb("inject manifest in head", t => {
     }
   };
 
-  const pluginEvent = (compilerEvent, compile) => {
-    t.is(compilerEvent, "compilation");
+  const pluginEvent = (event, compile) => {
+    if (event === "compilation") {
+      const assets = {};
+      assets[manifestFilename] = {
+        source: () => manifestFileContent
+      };
 
-    const assets = {};
-    assets[manifestFilename] = {
-      source: () => manifestFileContent
-    };
+      const compilation = {
+        plugin: compilationPluginEvent,
+        assets: assets
+      };
 
-    const compilation = {
-      plugin: compilationPluginEvent,
-      assets: assets
-    };
-
-    compile(compilation);
+      compile(compilation);
+    }
   };
 
   const fakeCompiler = { plugin: pluginEvent };


### PR DESCRIPTION
As described in issue https://github.com/jouni-kantola/inline-chunk-manifest-html-webpack-plugin/issues/8 sometimes more info is needed than generated by `chunk-manifest-webpack-plugin`.

This PR handles:
- Option to override default plugin(s) used to generate chunk manifest
```javascript
manifestPlugins: [/* plugins to apply goes here */]
```
- To completely ignore applying dependency plugins and extracting plugin, the following config can be used:
```javascript
extractManifest: false // default: true
```