### PR TITLE
Bump chunk-manifest-webpack-plugin version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "prettier": "^1.1.0"
   },
   "dependencies": {
-    "chunk-manifest-webpack-plugin": "~1.1.1"
+    "chunk-manifest-webpack-plugin": "~1.1.2"
   },
   "scripts": {
     "lint": "node_modules/.bin/eslint ./src",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "prettier": "^1.1.0"
   },
   "dependencies": {
-    "chunk-manifest-webpack-plugin": "~1.0.0"
+    "chunk-manifest-webpack-plugin": "~1.1.1"
   },
   "scripts": {
     "lint": "node_modules/.bin/eslint ./src",


### PR DESCRIPTION
To support webpack 3 in peer dependencies. Would be great to get this merged and published asap as it is a blocker for upgrading to webpack 3.

Resolves https://github.com/jouni-kantola/inline-chunk-manifest-html-webpack-plugin/issues/16

*Kept the tilde range but a more typical semver caret range might be more appropriate in future.*